### PR TITLE
Use concat-seq instead of concat.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [grafter/grafter "0.11.2"]
                  [grafter/extra "0.2.2-grafter-0.11.2-SNAPSHOT"]
-                 [csv2rdf "0.2.0"]
+                 [csv2rdf "0.2.2-SNAPSHOT"]
                  [org.clojure/data.csv "0.1.4"]
                  [net.cgrand/xforms "0.16.0"]
                  [environ "1.1.0"]]

--- a/src/table2qb/core.clj
+++ b/src/table2qb/core.clj
@@ -10,6 +10,7 @@
             [clojure.java.shell :refer [sh]]
             [environ.core :as environ]
             [csv2rdf.csvw :as csvw]
+            [csv2rdf.util :refer [concat-seq]]
             [grafter.rdf :as rdf]))
 
 ;; Config
@@ -557,14 +558,13 @@
               observations-csv observations-json
               used-codes-codelists-json used-codes-codes-json)
 
-  ;;TODO: don't use concat
-  (concat
-    (csvw/csv->rdf component-specifications-csv component-specifications-json {:mode :standard})
-    (csvw/csv->rdf component-specifications-csv dataset-json {:mode :standard})
-    (csvw/csv->rdf component-specifications-csv data-structure-definition-json {:mode :standard})
-    (csvw/csv->rdf observations-csv observations-json {:mode :standard})
-    (csvw/csv->rdf component-specifications-csv used-codes-codelists-json {:mode :standard})
-    (csvw/csv->rdf observations-csv used-codes-codes-json {:mode :standard})))
+  (concat-seq
+    [(csvw/csv->rdf component-specifications-csv component-specifications-json {:mode :standard})
+     (csvw/csv->rdf component-specifications-csv dataset-json {:mode :standard})
+     (csvw/csv->rdf component-specifications-csv data-structure-definition-json {:mode :standard})
+     (csvw/csv->rdf observations-csv observations-json {:mode :standard})
+     (csvw/csv->rdf component-specifications-csv used-codes-codelists-json {:mode :standard})
+     (csvw/csv->rdf observations-csv used-codes-codes-json {:mode :standard})]))
 
 (defn cube-pipeline [input-csv dataset-name dataset-slug]
   (let [component-specifications-csv (tempfile "component-specifications" ".csv")


### PR DESCRIPTION
Calling concat with more than two arguments causes the additional
sequences to be stored in an array which holds onto their heads as
they are iterated. Replace call to concat within cube-pipeline
with concat-seq which avoids holding onto sequence heads.