### PR TITLE
Generate columns in intermediate codelist CSV for top concepts.

### DIFF
--- a/examples/regional-trade/csvw/flow-directions.json
+++ b/examples/regional-trade/csvw/flow-directions.json
@@ -24,19 +24,19 @@
       "propertyUrl": "skos:broader",
       "valueUrl": "http://gss-data.org.uk/def/concept/flow-directions/{parent_notation}"
     },{
+      "name": "top_concept_of",
+      "titles": "top_concept_of",
+      "propertyUrl": "skos:topConceptOf",
+      "valueUrl": "http://gss-data.org.uk/def/concept-scheme/flow-directions"
+    }, {
+      "name": "has_top_concept",
+      "titles" "has_top_concept",
+      "aboutUrl": "http://gss-data.org.uk/def/concept-scheme/flow-directions",
+      "propertyUrl": "skos:hasTopConcept",
+      "valueUrl": "http://gss-data.org.uk/def/concept/flow-directions/{notation}"
+    }, {
       "propertyUrl": "skos:inScheme",
       "valueUrl": "http://gss-data.org.uk/def/concept-scheme/flow-directions",
-      "virtual": true
-    },{
-      "propertyUrl": "skos:topConceptOf",
-      "valueUrl": "http://gss-data.org.uk/def/concept-scheme/flow-directions",
-      "how-to-make-this-only-apply-when-parent-is-null?": "perhaps reasoning?",
-      "virtual": true
-    },,{
-      "propertyUrl": "skos:hasTopConcept",
-      "aboutUrl": "http://gss-data.org.uk/def/concept-scheme/flow-directions",
-      "valueUrl": "http://gss-data.org.uk/def/concept/flow-directions/{notation}",
-      "how-to-make-this-only-apply-when-parent-is-null?": "perhaps reasoning?",
       "virtual": true
     },{
       "propertyUrl": "skos:member",

--- a/test/table2qb/core_test.clj
+++ b/test/table2qb/core_test.clj
@@ -93,7 +93,7 @@
         (testing "one row per code"
           (is (= 2 (count codes))))
         (testing "one column per attribute"
-          (is (= [:label :notation :parent_notation]
+          (is (= [:label :notation :parent_notation :top_concept_of :has_top_concept]
                  (-> codes first keys)))))))
   (testing "json metadata"
     (with-open [target-reader (io/reader (example-csvw "regional-trade" "flow-directions.json"))]


### PR DESCRIPTION
Add columns to the intermediate codelist CSV which indicates whether
the current row is a top concept of the schema (i.e. its Parent Notation
is column is empty). Update the codelist metadata to output
skos:hasTopConcept and skos:topConceptOf statements for the corresponding
columns when they are non-empty. Remove the virtual columns that were
previously used to unconditionally output the skos:hasTopConcept and
skos:topConceptOf statements.