### PR TITLE
Convert tabular files into URIs when constructing metadata.

### DIFF
--- a/src/table2qb/pipelines/codelist.clj
+++ b/src/table2qb/pipelines/codelist.clj
@@ -4,7 +4,8 @@
             [clojure.java.io :as io]
             [table2qb.csv :refer [write-csv-rows read-csv]]
             [table2qb.util :refer [create-metadata-source tempfile]]
-            [clojure.string :as string]))
+            [clojure.string :as string])
+  (:import [java.io File]))
 
 (defn codelist-metadata [csv-url domain-def codelist-name codelist-slug]
   (let [codelist-uri (str domain-def "concept-scheme/" codelist-slug)
@@ -102,9 +103,9 @@
 
 (defn codelist->csvw->rdf
   "Annotates an input codelist CSV file and uses it to generate RDF for the given codelist name and slug."
-  [codelist-csv domain-def codelist-name codelist-slug intermediate-file]
+  [codelist-csv domain-def codelist-name codelist-slug ^File intermediate-file]
   (codelist->csvw codelist-csv intermediate-file)
-  (let [codelist-meta (codelist-metadata intermediate-file domain-def codelist-name codelist-slug)]
+  (let [codelist-meta (codelist-metadata (.toURI intermediate-file) domain-def codelist-name codelist-slug)]
     (csvw/csv->rdf intermediate-file (create-metadata-source codelist-csv codelist-meta) csv2rdf-config)))
 
 (defn codelist-pipeline

--- a/src/table2qb/pipelines/components.clj
+++ b/src/table2qb/pipelines/components.clj
@@ -4,7 +4,8 @@
             [csv2rdf.csvw :as csvw]
             [clojure.java.io :as io]
             [table2qb.csv :refer [write-csv-rows read-csv]]
-            [grafter.extra.cell.uri :as gecu]))
+            [grafter.extra.cell.uri :as gecu])
+  (:import [java.io File]))
 
 (defn components-metadata [csv-url domain-def]
   (let [ontology-uri (str domain-def "ontology/components")]
@@ -101,9 +102,9 @@
 
 (defn components->csvw->rdf
   "Annotates an input components CSV file and uses it to generate RDF."
-  [components-csv domain-def intermediate-file]
+  [components-csv domain-def ^File intermediate-file]
   (components->csvw components-csv intermediate-file)
-  (let [components-meta (components-metadata intermediate-file domain-def)]
+  (let [components-meta (components-metadata (.toURI intermediate-file) domain-def)]
     (csvw/csv->rdf intermediate-file (create-metadata-source components-csv components-meta) csv2rdf-config)))
 
 (defn components-pipeline

--- a/src/table2qb/util.clj
+++ b/src/table2qb/util.clj
@@ -16,8 +16,10 @@
     (fn [element]
       (get item->index element (count s)))))
 
-(defn csv-file->metadata-uri [csv-file]
-  (.resolve (.toURI csv-file) "meta.json"))
+(defn csv-file->metadata-uri [^File csv-file]
+  (let [csv-dir (.getParentFile csv-file)
+        meta-file (io/file csv-dir "meta.json")]
+    (.toURI meta-file)))
 
 (defn create-metadata-source [csv-file-str metadata-json]
   (let [meta-uri (csv-file->metadata-uri (io/file csv-file-str))]


### PR DESCRIPTION
Issue #77 - Use the URI representation of the corresponding tabular
data file when building csv2rdf metadata. Pipeline metadata functions
(.e.g codelist/codelist-metadata) expect to be passed the URI of the
corresponding tabular file. The file object for the temporary
intermediate file was previously being passed directly. On *nix
systems this file is an absolute path to the file
e.g. /var/tmp/file.csv. When this path is resolved against the metadata
URI, this still correctly refers to the temp file path. Absolute
Windows paths are not valid URIs due to the leading directory segment,
so these fail to resolve, resulting in the tabular file not being
located.